### PR TITLE
Scripts exports non-project groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,6 @@ pat.txt
 
 # ignore visual studio code files
 .vscode/
+
+#ignore csv output files
+*.csv

--- a/CreateADOGraph.ps1
+++ b/CreateADOGraph.ps1
@@ -1,7 +1,7 @@
 #credits to https://github.com/KevinMarquette/PSGraph
-Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
-choco install graphviz
-Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; Find-Module PSGraph | Install-Module
+#Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+#choco install graphviz
+#Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; Find-Module PSGraph | Install-Module
 
 # alternative ways of installing GraphViz are provided here
 # https://graphviz.org/download/
@@ -21,7 +21,5 @@ graph g {
 
 }
 
-.\GetMembershipREST.ps1
-
-CreateGraph "filename.csv"
-
+.\GetMembershipREST.ps1 -orgName adamjag-demo
+Get-ChildItem -Path *.csv | ForEach-Object { CreateGraph $_.Name }

--- a/CreateADOGraph.ps1
+++ b/CreateADOGraph.ps1
@@ -15,7 +15,7 @@ function CreateGraph {
 $membership = Import-Csv -Path $fileName -Delimiter ";"
 
 graph g {
-    node $membership -NodeScript { $_.descriptor} @{label={$_.DisplayName}}
+    node $membership -NodeScript { $_.descriptor} @{label={$_.principalName}}
     edge $membership -FromScript {$_.ParentDescriptor} -ToScript {$_.descriptor}
 } | Export-PSGraph -ShowGraph
 

--- a/GetMembershipREST.ps1
+++ b/GetMembershipREST.ps1
@@ -114,13 +114,14 @@ $projects.value | ForEach-Object {
     #to fix issue #2 we need to add to the project scoped membership the membership to organization scoped groups 
     # we reiterate the lists to find the 'up' directed membership
     $discoveredOrgScopedIdentities = @()
-    foreach($proejctIdentity in $projectResult)
+    $uniqueProjectDescriptors = $projectResult | select descriptor -Unique
+    foreach($itemDescriptor in $uniqueProjectDescriptors  )
     {
-         $identityMemberOfObjects = GetMembersOfFromDescriptorREST $proejctIdentity.descriptor $orgName $proejctIdentity.principalName 2 $header
+        $proejctIdentity = $projectResult | Where-Object {$_.descriptor -eq $itemDescriptor.descriptor} 
+        $identityMemberOfObjects = GetMembersOfFromDescriptorREST $proejctIdentity.descriptor $orgName $proejctIdentity.principalName 2 $header
        
         foreach ($parentIdentity in $identityMemberOfObjects)
         {
-           
             if( $projectGroups.descriptor -notcontains $parentIdentity.descriptor)
             {
                 $parentDetails = GetMemberDetails $orgName $parentIdentity.descriptor $header 0
@@ -128,8 +129,6 @@ $projects.value | ForEach-Object {
                 $discoveredOrgScopedIdentities += CreateMemeberRecord $proejctIdentity $parentIdentity.descriptor
             }
         }
-        
-
     }
     $projectResult += $discoveredOrgScopedIdentities
 

--- a/GetMembershipREST.ps1
+++ b/GetMembershipREST.ps1
@@ -117,15 +117,18 @@ $projects.value | ForEach-Object {
     $uniqueProjectDescriptors = $projectResult | select descriptor -Unique
     foreach($itemDescriptor in $uniqueProjectDescriptors  )
     {
-        $proejctIdentity = $projectResult | Where-Object {$_.descriptor -eq $itemDescriptor.descriptor} 
+        $proejctIdentity = $projectResult | Where-Object {$_.descriptor -eq $itemDescriptor.descriptor} | select -First 1
         $identityMemberOfObjects = GetMembersOfFromDescriptorREST $proejctIdentity.descriptor $orgName $proejctIdentity.principalName 2 $header
        
         foreach ($parentIdentity in $identityMemberOfObjects)
         {
             if( $projectGroups.descriptor -notcontains $parentIdentity.descriptor)
             {
-                $parentDetails = GetMemberDetails $orgName $parentIdentity.descriptor $header 0
-                $discoveredOrgScopedIdentities += CreateMemeberRecord $parentDetails $orgName
+                if ($discoveredOrgScopedIdentities.descriptor -notcontains $parentIdentity.descriptor )
+                {
+                    $parentDetails = GetMemberDetails $orgName $parentIdentity.descriptor $header 0
+                    $discoveredOrgScopedIdentities += CreateMemeberRecord $parentDetails $orgName
+                }
                 $discoveredOrgScopedIdentities += CreateMemeberRecord $proejctIdentity $parentIdentity.descriptor
             }
         }


### PR DESCRIPTION
Fixes #2 , note that all security groups from non-current project will be exported without project related info or other information about the scope